### PR TITLE
feat: create user commands CatatlogLensEnable, CatalogLensDisable and CatalogLensToggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,13 @@ The plugin will automatically detect package catalogs and show inline version in
 
 ### Commands
 
-You can use the following Lua functions to control the plugin:
+You can use user cmmands to control the plugin:
+
+- `CatalogLensEnable`: Enable the plugin and LSP.
+- `CatalogLensDisable`: Disable the plugin and LSP.
+- `CatalogLensToggle`: Toggle the plugin state.
+
+You can also use the Lua API:
 
 - `require("catalog-lens").enable()`: Enable the plugin and LSP.
 - `require("catalog-lens").disable()`: Disable the plugin and LSP.

--- a/lua/catalog-lens/api.lua
+++ b/lua/catalog-lens/api.lua
@@ -1,0 +1,23 @@
+local config = require("catalog-lens.config")
+
+local M = {}
+
+function M.enable()
+  config.enabled = true
+  vim.lsp.enable("catalog_ls", true)
+end
+
+function M.disable()
+  config.enabled = false
+  vim.lsp.enable("catalog_ls", false)
+end
+
+function M.toggle()
+  if config.enabled then
+    M.disable()
+  else
+    M.enable()
+  end
+end
+
+return M

--- a/lua/catalog-lens/init.lua
+++ b/lua/catalog-lens/init.lua
@@ -1,33 +1,45 @@
+local api = require("catalog-lens.api")
+local config = require("catalog-lens.config")
+local lsp = require("catalog-lens.lsp")
+
 local M = {}
 
+--Create user commands belongs to this plugin
+local function create_user_commands()
+  vim.api.nvim_create_user_command("CatalogLensEnable", api.enable, { desc = "Enable Catalog Lens" })
+  vim.api.nvim_create_user_command("CatalogLensDisable", api.disable, { desc = "Disable Catalog Lens" })
+  vim.api.nvim_create_user_command("CatalogLensToggle", api.toggle, { desc = "Toggle Catalog Lens" })
+end
+
+--Expose API functions
+local function expose_api_functions()
+  function M.enable()
+    api.enable()
+  end
+
+  function M.disable()
+    api.disable()
+  end
+
+  function M.toggle()
+    api.toggle()
+  end
+end
+
+---Setup catalog-lens
 ---@param opts? catalog-lens.Config
 function M.setup(opts)
-  require("catalog-lens.config").setup(opts)
+  config.setup(opts)
 
   local server_paths = vim.api.nvim_get_runtime_file("catalog-lens-lsp/server.js", false)[1]
-  require("catalog-lens.lsp").setup(server_paths)
+  lsp.setup(server_paths)
 
-  if not require("catalog-lens.config").enabled then
-    M.disable()
+  if not config.enabled then
+    api.disable()
   end
-end
 
-function M.enable()
-  require("catalog-lens.config").enabled = true
-  vim.lsp.enable("catalog_ls", true)
-end
-
-function M.disable()
-  require("catalog-lens.config").enabled = false
-  vim.lsp.enable("catalog_ls", false)
-end
-
-function M.toggle()
-  if require("catalog-lens.config").enabled then
-    M.disable()
-  else
-    M.enable()
-  end
+  expose_api_functions()
+  create_user_commands()
 end
 
 return M


### PR DESCRIPTION
# Create user commands `CatatlogLensEnable`, `CatalogLensDisable` and `CatalogLensToggle`

## Description

Provide user commands to control the plugin.

Before:
- `:lua require("catalog-lens").enable()`
- `:lua require("catalog-lens").disable()`
- `:lua require("catalog-lens").toggle()`

After:
- `:CatatlogLensEnable`
- `:CatalogLensDisable`
- `:CatalogLensToggle`

## Related Issue(s)

No

## Screenshots

<img width="822" height="170" alt="image" src="https://github.com/user-attachments/assets/2445dfec-fb4d-48c0-9ba4-c43ca24dbaa0" />

